### PR TITLE
Use free icon set

### DIFF
--- a/app/templates/components/critter-table-row.hbs
+++ b/app/templates/components/critter-table-row.hbs
@@ -17,7 +17,7 @@
 {{/if}}
 {{#if newCritter}}
   <tr>
-    <td colspan="4" class="border-top-0 pt-0 text-info">{{fa-icon "badge-check" prefix="fas"}} {{t "critterInSeason"}}</td>
+    <td colspan="4" class="border-top-0 pt-0 text-info">{{fa-icon "asterisk" prefix="fas"}} {{t "critterInSeason"}}</td>
   </tr>
 {{/if}}
 {{yield}}

--- a/config/icons.js
+++ b/config/icons.js
@@ -3,7 +3,7 @@
  * At build time, this file is used to create a custom fontawesome font file
  * containing only the icons that are required for the application. This file
  * dramatically reduces the size of the compiled application.
- * 
+ *
  * Any new icons that are required, also need to be added to this file.
  */
 
@@ -12,14 +12,16 @@ module.exports = function() {
     'free-brands-svg-icons': [
       'twitter'
     ],
-    'pro-solid-svg-icons': [
+    'free-solid-svg-icons': [
       'chevron-left',
       'cog',
       'sort',
       'sort-down',
       'sort-up',
-      'badge-check',
+      'asterisk',
+      'certificate',
       'exclamation-triangle',
+      'calendar-plus',
       'info-circle'
     ]
   };

--- a/config/icons.js
+++ b/config/icons.js
@@ -19,9 +19,7 @@ module.exports = function() {
       'sort-down',
       'sort-up',
       'asterisk',
-      'certificate',
       'exclamation-triangle',
-      'calendar-plus',
       'info-circle'
     ]
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2057,10 +2057,10 @@
         "@fortawesome/fontawesome-common-types": "^0.2.28"
       }
     },
-    "@fortawesome/pro-solid-svg-icons": {
+    "@fortawesome/free-solid-svg-icons": {
       "version": "5.13.0",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/pro-solid-svg-icons/-/5.13.0/pro-solid-svg-icons-5.13.0.tgz",
-      "integrity": "sha512-MK3ycWLTTDw2xdY5BOQU3KYcGFk07Lj1Ub+EAlEAs9WcSgw7meEO3acPBpgNXUPB11gsI/4o9h+UxzJM1u+L8g==",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.13.0.tgz",
+      "integrity": "sha512-IHUgDJdomv6YtG4p3zl1B5wWf9ffinHIvebqQOmV3U+3SLw4fC+LUCCgwfETkbTtjy5/Qws2VoVf6z/ETQpFpg==",
       "dev": true,
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.28"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@ember/optional-features": "^0.7.0",
     "@fortawesome/ember-fontawesome": "^0.2.1",
     "@fortawesome/free-brands-svg-icons": "^5.13.0",
-    "@fortawesome/pro-solid-svg-icons": "^5.13.0",
+    "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@types/ember": "^3.1.2",
     "bootstrap": "^4.4.1",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
I had trouble getting the app running locally because I don’t have access to [Fort Awesome Pro](https://fontawesome.com/how-to-use/on-the-web/setup/using-package-managers#installing-pro), so the required `@fortawesome/pro-solid-svg-icons` package couldn’t install.

This PR changes the dependency to use the `@fortawesome/free-solid-svg-icons` package instead. It also replaces the only "pro" icon instance, shown in context below:

| Before | After |
| --- | --- |
| ![Screen-Shot-2020-04-06-at-4 59 21-PM](https://user-images.githubusercontent.com/221550/78604828-6531aa00-7828-11ea-9478-699618c80ed7.png) | ![Screen-Shot-2020-04-06-at-4 59 38-PM](https://user-images.githubusercontent.com/221550/78604743-44695480-7828-11ea-9909-b61ed9bc73a9.png)
